### PR TITLE
トップ画面からジャンル検索をするとき、keywordのstateをリセットする

### DIFF
--- a/app/javascript/pages/item/components/RakutenApiError.vue
+++ b/app/javascript/pages/item/components/RakutenApiError.vue
@@ -1,20 +1,23 @@
 <template>
   <article
     v-if="error"
-    class="message is-danger error-msg"
+    class="error-msg"
     aria-close-label="Close message"
   >
-    <div class="message-body">
+    <div>
       {{ errorMessage(error) }}
       <div>
         <b-button
-          type="is-text"
+          type="is-danger"
+          class="reset-btn"
+          expanded
           @click="reset()"
         >
           検索条件をリセットする
         </b-button>
       </div>
     </div>
+    <img src="../../../../assets/images/top_image_pink.JPG">
   </article>
 </template>
 
@@ -65,6 +68,10 @@ export default {
 
 <style scoped>
 .error-msg {
-  margin-top: 8rem !important;
+  margin-top: 3rem !important;
+  text-align: center;
+}
+.reset-btn {
+  margin-bottom: 2rem;
 }
 </style>

--- a/app/javascript/pages/item/components/RakutenApiResultHit.vue
+++ b/app/javascript/pages/item/components/RakutenApiResultHit.vue
@@ -36,7 +36,7 @@
                 class="tag reset-tag"
                 @click="resetSearch()"
               >
-                検索条件の解除
+                検索条件のリセット
               </b-button>
             </b-taglist>
           </div>
@@ -116,7 +116,7 @@
           class="tag reset-tag"
           @click="resetSearch()"
         >
-          検索条件の解除
+          検索条件のリセット
         </b-button>
       </b-taglist>
     </div>
@@ -374,7 +374,7 @@ export default {
     display: flex;
   }
   .hit-count {
-    font-size: 0.5rem;
+    font-size: 0.7rem;
     line-height: 2rem;
     margin-left: 1rem;
   }

--- a/app/javascript/pages/item/components/RakutenApiResultList.vue
+++ b/app/javascript/pages/item/components/RakutenApiResultList.vue
@@ -17,8 +17,9 @@
         </div>
       <div>
         <b-button
-          type="is-link is-light"
+          type="is-danger"
           class="reset-btn"
+          expanded
           @click="reset()"
         >
           検索条件をリセットする

--- a/app/javascript/pages/item/index.vue
+++ b/app/javascript/pages/item/index.vue
@@ -14,12 +14,12 @@
       </b-sidebar>
       <div class="container inner">
         <RakutenApiCall v-show="!loading" />
-        <RakutenApiError v-show="!loading" />
         <ResponsiveRelationshipSearch v-show="!loading" class="rps-rs-s" />
         <RakutenApiResultHit v-show="!loading" />
         <Loading v-show="loading" />
         <RakutenApiPagenation v-show="!loading" />
         <RakutenApiResultList v-show="!loading" />
+        <RakutenApiError v-show="!loading" />
         <RakutenApiPagenation
           v-show="!loading"
           style="margin-top:2rem"

--- a/app/javascript/pages/top/components/RelationshipRakutenApiCall.vue
+++ b/app/javascript/pages/top/components/RelationshipRakutenApiCall.vue
@@ -32,7 +32,7 @@
                 changeGenreId(friend_search_card.genreId);
                 changeMinPrice(10000);
                 changeMaxPrice(30000);
-                search();
+                genreSearch();
               "
             >
               <div class="card-image">
@@ -84,7 +84,7 @@
                 changeGenreId(relative_search_card.genreId);
                 changeMinPrice(30000);
                 changeMaxPrice(50000);
-                search();
+                genreSearch();
               "
             >
               <div class="card-image">
@@ -136,7 +136,7 @@
                 changeGenreId(colleague_search_card.genreId);
                 changeMinPrice(10000);
                 changeMaxPrice(20000);
-                search();
+                genreSearch();
               "
             >
               <div class="card-image">
@@ -188,7 +188,7 @@
                 changeGenreId(boss_search_card.genreId);
                 changeMinPrice(1000);
                 changeMaxPrice(5000);
-                search();
+                genreSearch();
               "
             >
               <div class="card-image">
@@ -219,6 +219,7 @@ import {
   changeMaxPrice,
   changeSort,
   search,
+  genreSearch,
 } from "../../../store/mutation-types";
 export default {
   name: "RelationshipRakutenApiCall",
@@ -373,6 +374,7 @@ export default {
       "changeMaxPrice",
       "changeSort",
       "search",
+      "genreSearch",
     ]),
   },
 };
@@ -462,5 +464,3 @@ export default {
 }
 }
 </style>
-
-// :src="require('../../../../assets/images/logo_light_pink.JPG')"


### PR DESCRIPTION
追加で、errorページのCSS変更
リセットボタンをerror-messageのフレームワークから、普通のbuttonのCSS＋expandedにした
error画像を追加